### PR TITLE
Update setup.sh to use NWL23 instead of NWL20

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -48,7 +48,7 @@ docker run --rm \
     -v $cwd/letterdistributions:/opt/data/letterdistributions \
     -v $cwd/lexica/db:/db \
     -e WDB_DATA_PATH=/opt/data \
-    domino14/word_db_server ./dbmaker -dbs NWL20,CSW21 -outputdir /db
+    domino14/word_db_server ./dbmaker -dbs NWL23,CSW21 -outputdir /db
 
 # GOTO_1
 


### PR DESCRIPTION
WordVault doesn't include NWL20 by default, so this is a slightly simpler set-up process